### PR TITLE
feat: make hkdf generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ dependencies = [
  "bls-crypto",
  "blst",
  "criterion",
+ "digest 0.10.3",
  "ed25519-dalek",
  "eyre",
  "hex",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -18,8 +18,7 @@ zeroize = "1.5.1"
 signature = "1.5.0"
 tokio = { version = "1.19.2", features = ["sync", "rt", "macros"] }
 ark-bls12-377 = { version = "0.3.0", features = ["std"], optional = true }
-hkdf = "0.12.3"
-sha3 = "0.10.1"
+hkdf = { version = "0.12.3", features = ["std"] }
 serde_with = "1.14.0"
 schemars ="0.8.10"
 
@@ -37,6 +36,7 @@ once_cell = "1.12.0"
 readonly = "0.2.1"
 serde_bytes = "0.11.6"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+digest = "0.10.3"
 
 [[bench]]
 name = "crypto"
@@ -53,3 +53,4 @@ copy_key = []
 [dev-dependencies]
 bincode = "1.3.3"
 criterion = "0.3.5"
+sha3 = "0.10.1"


### PR DESCRIPTION
- we reduce things to a single HKDF function,
- the caller is free to use it with any (hash function, keypair) pair of implementation they choose,
- they are responsible for checking the output of the hash function is able to produce a byte string of the length of the private key representation.

Adds a code example