### PR TITLE
Simplify Aggregation a bit

### DIFF
--- a/crypto/src/hkdf.rs
+++ b/crypto/src/hkdf.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::traits::{KeyPair, SigningKey, ToFromBytes, DEFAULT_DOMAIN};
+use digest::{
+    block_buffer::Eager,
+    consts::U256,
+    core_api::{BlockSizeUser, BufferKindUser, CoreProxy, FixedOutputCore, UpdateCore},
+    typenum::{IsLess, Le, NonZero, Unsigned},
+    HashMarker, OutputSizeUser,
+};
+use hkdf::hmac::Hmac;
+
+/// Creation of a keypair using the [RFC 5869](https://tools.ietf.org/html/rfc5869) HKDF specification.
+/// This requires choosing an HMAC function of the correct length (conservatively, the size of a private key for this curve).
+/// Despite the unsightly generics (which aim to ensure this works for a wide range of hash functions), this is straightforward to use.
+///
+/// Example:
+/// ```rust
+/// use sha3::Sha3_256;
+/// use crypto::ed25519::Ed25519KeyPair;
+/// use crypto::traits::hkdf_generate_from_ikm;
+/// # fn main() {
+///     let ikm = b"some_ikm";
+///     let domain = b"my_app";
+///     let salt = b"some_salt";
+///     let my_keypair = hkdf_generate_from_ikm::<Sha3_256, Ed25519KeyPair>(ikm, salt, Some(domain));
+///
+///     let my_keypair_default_domain = hkdf_generate_from_ikm::<Sha3_256, Ed25519KeyPair>(ikm, salt, None);
+/// # }
+/// ```
+pub fn hkdf_generate_from_ikm<'a, H: OutputSizeUser, K: KeyPair>(
+    ikm: &[u8],             // IKM (32 bytes)
+    salt: &[u8],            // Optional salt
+    info: Option<&'a [u8]>, // Optional domain
+) -> Result<K, signature::Error>
+where
+    // This is a tad tedious, because of hkdf's use of a sealed trait. But mostly harmless.
+    H: CoreProxy + OutputSizeUser,
+    H::Core: HashMarker
+        + UpdateCore
+        + FixedOutputCore
+        + BufferKindUser<BufferKind = Eager>
+        + Default
+        + Clone,
+    <H::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
+    Le<<H::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+{
+    let info = info.unwrap_or(&DEFAULT_DOMAIN);
+    let hk = hkdf::Hkdf::<H, Hmac<H>>::new(Some(salt), ikm);
+    // we need the HKDF to be able to expand precisely to the byte length of a Private key for the chosen KeyPair parameter.
+    // This check is a tad over constraining (check Hkdf impl for a more relaxed variant) but is always correct.
+    if H::OutputSize::USIZE != K::PrivKey::LENGTH {
+        return Err(signature::Error::from_source(hkdf::InvalidLength));
+    }
+    let mut okm = vec![0u8; K::PrivKey::LENGTH];
+    hk.expand(info, &mut okm)
+        .map_err(|_| signature::Error::new())?;
+
+    let secret_key = K::PrivKey::from_bytes(&okm[..]).map_err(|_| signature::Error::new())?;
+
+    let keypair = K::from(secret_key);
+    Ok(keypair)
+}

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -38,6 +38,7 @@ pub mod bls12381_tests;
 
 pub mod bls12381;
 pub mod ed25519;
+pub mod hkdf;
 pub mod serde_helpers;
 pub mod traits;
 

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -39,6 +39,7 @@ pub mod bls12381_tests;
 pub mod bls12381;
 pub mod ed25519;
 pub mod hkdf;
+pub mod pubkey_bytes;
 pub mod serde_helpers;
 pub mod traits;
 

--- a/crypto/src/pubkey_bytes.rs
+++ b/crypto/src/pubkey_bytes.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use self::sealed::SealedPublicKeyLength;
+use crate::traits::{ToFromBytes, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, Bytes};
+use std::{fmt::Display, marker::PhantomData};
+
+/// A generic construction representing bytes who claim to be the instance of a public key.
+#[serde_as]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct PublicKeyBytes<T, const N: usize> {
+    #[serde_as(as = "Bytes")]
+    bytes: [u8; N],
+    phantom: PhantomData<T>,
+}
+
+impl<T, const N: usize> AsRef<[u8]> for PublicKeyBytes<T, N>
+where
+    T: VerifyingKey,
+{
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes[..]
+    }
+}
+
+impl<T, const N: usize> Display for PublicKeyBytes<T, N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        let s = hex::encode(&self.bytes);
+        write!(f, "k#{}", s)?;
+        Ok(())
+    }
+}
+
+impl<T: VerifyingKey, const N: usize> ToFromBytes for PublicKeyBytes<T, N> {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
+        let bytes: [u8; N] = bytes.try_into().map_err(signature::Error::from_source)?;
+        Ok(PublicKeyBytes {
+            bytes,
+            phantom: PhantomData,
+        })
+    }
+}
+
+impl<T, const N: usize> PublicKeyBytes<T, N> {
+    /// This ensures it's impossible to construct an instance with other than registered lengths
+    pub fn new(bytes: [u8; N]) -> PublicKeyBytes<T, N>
+    where
+        PublicKeyBytes<T, N>: SealedPublicKeyLength,
+    {
+        PublicKeyBytes {
+            bytes,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, const N: usize> Default for PublicKeyBytes<T, N> {
+    // this is probably derivable, but we'd rather have it explicitly laid out for instructional purposes,
+    // see [#34](https://github.com/MystenLabs/narwhal/issues/34)
+    fn default() -> Self {
+        Self {
+            bytes: [0u8; N],
+            phantom: PhantomData,
+        }
+    }
+}
+
+// This guarantees the security of the constructor of a `PublicKeyBytes` instance 
+// TODO: replace this clunky sealed marker trait once feature(associated_const_equality) stabilizes
+mod sealed {
+    #[cfg(feature = "celo")]
+    use crate::bls12377::BLS12377PublicKey;
+    use crate::{bls12381::BLS12381PublicKey, ed25519::Ed25519PublicKey, traits::VerifyingKey};
+
+    use super::PublicKeyBytes;
+
+    pub trait SealedPublicKeyLength {}
+    impl SealedPublicKeyLength for PublicKeyBytes<Ed25519PublicKey, { Ed25519PublicKey::LENGTH }> {}
+    impl SealedPublicKeyLength for PublicKeyBytes<BLS12381PublicKey, { BLS12381PublicKey::LENGTH }> {}
+    #[cfg(feature = "celo")]
+    impl SealedPublicKeyLength for PublicKeyBytes<BLS12377PublicKey, { BLS12377PublicKey::LENGTH }> {}
+}

--- a/crypto/src/traits.rs
+++ b/crypto/src/traits.rs
@@ -92,7 +92,6 @@ pub trait VerifyingKey:
 {
     type PrivKey: SigningKey<PubKey = Self>;
     type Sig: Authenticator<PubKey = Self>;
-    type Bytes: VerifyingKeyBytes<PubKey = Self>;
     const LENGTH: usize;
 
     // Expected to be overridden by implementations
@@ -153,7 +152,6 @@ pub trait KeyPair: Sized + From<Self::PrivKey> {
     fn copy(&self) -> Self;
 
     fn generate<R: CryptoRng + RngCore>(rng: &mut R) -> Self;
-    fn public_key_bytes(&self) -> <Self::PubKey as VerifyingKey>::Bytes;
 }
 
 /// Trait impl'd by aggregated signatures in asymmetric cryptography.
@@ -185,21 +183,4 @@ pub trait AggregateAuthenticator:
         pks: &[&[Self::PubKey]],
         messages: &[&[u8]],
     ) -> Result<(), Error>;
-}
-
-/// Trait impl'd byte representations of public keys in asymmetric cryptography.
-///
-pub trait VerifyingKeyBytes:
-    Display
-    + Default
-    + AsRef<[u8]>
-    + TryInto<Self::PubKey>
-    + Eq
-    + std::hash::Hash
-    + Copy
-    + Ord
-    + PartialOrd
-    + ToFromBytes
-{
-    type PubKey: VerifyingKey<Bytes = Self>;
 }

--- a/crypto/src/traits.rs
+++ b/crypto/src/traits.rs
@@ -3,16 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 use base64ct::Encoding;
 use eyre::eyre;
-use hkdf::hmac::Hmac;
+
 use rand::{CryptoRng, RngCore};
 
-use digest::{
-    block_buffer::Eager,
-    consts::U256,
-    core_api::{BlockSizeUser, BufferKindUser, CoreProxy, FixedOutputCore, UpdateCore},
-    typenum::{IsLess, Le, NonZero, Unsigned},
-    HashMarker, OutputSizeUser,
-};
 use serde::{de::DeserializeOwned, Serialize};
 pub use signature::{Error, Signer};
 use std::fmt::{Debug, Display};
@@ -161,58 +154,6 @@ pub trait KeyPair: Sized + From<Self::PrivKey> {
 
     fn generate<R: CryptoRng + RngCore>(rng: &mut R) -> Self;
     fn public_key_bytes(&self) -> <Self::PubKey as VerifyingKey>::Bytes;
-}
-
-/// Creation of a keypair using the [RFC 5869](https://tools.ietf.org/html/rfc5869) HKDF specification.
-/// This requires choosing an HMAC function of the correct length (conservatively, the size of a private key for this curve).
-/// Despite the unsightly generics (which aim to ensure this works for a wide range of hash functions), this is straightforward to use.
-///
-/// Example:
-/// ```rust
-/// use sha3::Sha3_256;
-/// use crypto::ed25519::Ed25519KeyPair;
-/// use crypto::traits::hkdf_generate_from_ikm;
-/// # fn main() {
-///     let ikm = b"some_ikm";
-///     let domain = b"my_app";
-///     let salt = b"some_salt";
-///     let my_keypair = hkdf_generate_from_ikm::<Sha3_256, Ed25519KeyPair>(ikm, salt, Some(domain));
-///
-///     let my_keypair_default_domain = hkdf_generate_from_ikm::<Sha3_256, Ed25519KeyPair>(ikm, salt, None);
-/// # }
-/// ```
-pub fn hkdf_generate_from_ikm<'a, H: OutputSizeUser, K: KeyPair>(
-    ikm: &[u8],             // IKM (32 bytes)
-    salt: &[u8],            // Optional salt
-    info: Option<&'a [u8]>, // Optional domain
-) -> Result<K, signature::Error>
-where
-    // This is a tad tedious, because of hkdf's use of a sealed trait. But mostly harmless.
-    H: CoreProxy + OutputSizeUser,
-    H::Core: HashMarker
-        + UpdateCore
-        + FixedOutputCore
-        + BufferKindUser<BufferKind = Eager>
-        + Default
-        + Clone,
-    <H::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
-    Le<<H::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
-{
-    let info = info.unwrap_or(&DEFAULT_DOMAIN);
-    let hk = hkdf::Hkdf::<H, Hmac<H>>::new(Some(salt), ikm);
-    // we need the HKDF to be able to expand precisely to the byte length of a Private key for the chosen KeyPair parameter.
-    // This check is a tad over constraining (check Hkdf impl for a more relaxed variant) but is always correct.
-    if H::OutputSize::USIZE != K::PrivKey::LENGTH {
-        return Err(signature::Error::from_source(hkdf::InvalidLength));
-    }
-    let mut okm = vec![0u8; K::PrivKey::LENGTH];
-    hk.expand(info, &mut okm)
-        .map_err(|_| signature::Error::new())?;
-
-    let secret_key = K::PrivKey::from_bytes(&okm[..]).map_err(|_| signature::Error::new())?;
-
-    let keypair = K::from(secret_key);
-    Ok(keypair)
 }
 
 /// Trait impl'd by aggregated signatures in asymmetric cryptography.


### PR DESCRIPTION
- refactor HKDF to its own file,
- `PubKeyBytes` can be defined more generically to help make the logic a bit more concise.